### PR TITLE
Added a check to avoid a possible exception

### DIFF
--- a/src/SeztionParser/Providers/SectionData.cs
+++ b/src/SeztionParser/Providers/SectionData.cs
@@ -64,7 +64,7 @@ namespace SeztionParser.Providers
                 sb.Append($"]{NewLine}");
                 return sb.ToString();
             }
-            return $"[{this[0]}]{NewLine}";
+            return Count == 0 ? $"[]{NewLine}" : $"[{this[0]}]{NewLine}";
         }
     }
 }


### PR DESCRIPTION
Although the parser does not allow a **section** to be empty, it does not hurt to add a check when the **section** is empty:
https://github.com/MrDave1999/seztion-parser/blob/f3020748eb40cd5b8dc18b16f17abc17bca66265/src/SeztionParser/Providers/SectionData.cs#L67
