### PR TITLE
Removed the .NET Standard 2.1 target framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![seztion-parser-logo](https://raw.githubusercontent.com/MrDave1999/seztion-parser/main/docs/images/seztionparser-logo.png)](https://github.com/mrdave1999/seztion-parser)
 
 [![seztion-parser](https://img.shields.io/badge/.NET%20Standard-2.0-red)](https://github.com/mrdave1999/seztion-parser)
-[![seztion-parser](https://img.shields.io/badge/.NET%20Standard-2.1-green)](https://github.com/mrdave1999/seztion-parser)
 [![seztion-parser](https://img.shields.io/badge/Class%20Library-Project-yellow)](https://github.com/mrdave1999/seztion-parser)
 [![Nuget-Badges](https://buildstats.info/nuget/seztion-parser)](https://www.nuget.org/packages/seztion-parser/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 [![seztion-parser](images/seztionparser-logo.png)](https://github.com/mrdave1999/seztion-parser)
 
 [![seztion-parser](https://img.shields.io/badge/.NET%20Standard-2.0-red)](https://github.com/mrdave1999/seztion-parser)
-[![seztion-parser](https://img.shields.io/badge/.NET%20Standard-2.1-green)](https://github.com/mrdave1999/seztion-parser)
 [![seztion-parser](https://img.shields.io/badge/Class%20Library-Project-yellow)](https://github.com/mrdave1999/seztion-parser)
 
 

--- a/src/SeztionParser/SeztionParser.csproj
+++ b/src/SeztionParser/SeztionParser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>David Román Amariles</Authors>
     <Product>Seztion Parser</Product>


### PR DESCRIPTION
No .NET Standard 2.1 functions are used, so it is unnecessary to add this target framework in the project file (.csproj).