### PR TITLE
fix: lock FluentAssertions version to 7.x to prevent unintended upgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="3.1.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.10.0" />
+    <PackageVersion Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.4.3" />


### PR DESCRIPTION
[FluentAssertions](https://github.com/fluentassertions/fluentassertions) became a paid library starting from version 8.0 and is no longer open source. This PR is created to prevent unintended upgrades to version 8.

For more details: https://github.com/fluentassertions/fluentassertions/pull/2943
Reference: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges