### PR TITLE
feat: add enum parsing support for single-line sections

### DIFF
--- a/src/SeztionParser.Tests/Reader/SingleLineSectionTests.cs
+++ b/src/SeztionParser.Tests/Reader/SingleLineSectionTests.cs
@@ -97,4 +97,66 @@ public class SingleLineSectionTests
         // Assert
         actual.Should().Be(expected);
     }
+
+    [TestMethod]
+    public void GetFirstLineEnum_WhenConversionIsValid_ShouldReturnEnum()
+    {
+        // Arrange
+        var data =
+        """
+        [section1]
+        Alpha
+        """;
+        var sections = new SectionsParser().Parse(data);
+        TestEnum expected = TestEnum.Alpha;
+
+        // Act
+        TestEnum actual = sections.GetFirstLineEnum<TestEnum>("section1");
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void GetFirstLineEnum_WhenIgnoreCaseIsTrue_ShouldReturnEnum()
+    {
+        // Arrange
+        var data =
+        """
+        [section1]
+        alpha
+        """;
+        var sections = new SectionsParser().Parse(data);
+        TestEnum expected = TestEnum.Alpha;
+
+        // Act
+        TestEnum actual = sections.GetFirstLineEnum<TestEnum>("section1", ignoreCase: true);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void GetFirstLineEnum_WhenValueIsInvalid_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var data =
+        """
+        [section1]
+        Invalid
+        """;
+        var sections = new SectionsParser().Parse(data);
+
+        // Act
+        Action action = () => sections.GetFirstLineEnum<TestEnum>("section1");
+
+        // Assert
+        action.Should().Throw<ArgumentException>();
+    }
+
+    private enum TestEnum
+    {
+        Alpha,
+        Beta
+    }
 }

--- a/src/SeztionParser/Reader/SingleLineSection.cs
+++ b/src/SeztionParser/Reader/SingleLineSection.cs
@@ -80,4 +80,23 @@ public static class SingleLineSection
     /// <returns>The first line in <c>string</c> format.</returns>
     public static string GetFirstLineString(this ISectionsData sections, string sectionName)
         => sections[sectionName][0];
+
+
+    /// <summary>
+    /// Gets the first line of the section in an enum format.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="sections">The data of sections.</param>
+    /// <param name="sectionName">The name of the section.</param>
+    /// <param name="ignoreCase">Whether the name comparison is case-insensitive.</param>
+    /// <exception cref="ArgumentException">
+    /// If the first line does not represent a valid value of <typeparamref name="TEnum" />.
+    /// </exception>
+    /// <exception cref="SectionNotFoundException">
+    /// If the <c>section</c> does not exist.
+    /// </exception>
+    /// <returns>The first line converted to <typeparamref name="TEnum" />.</returns>
+    public static TEnum GetFirstLineEnum<TEnum>(this ISectionsData sections, string sectionName, bool ignoreCase = false)
+        where TEnum : struct, Enum
+        => (TEnum)Enum.Parse(typeof(TEnum), sections[sectionName][0], ignoreCase);
 }


### PR DESCRIPTION
## Changes
* Add `GetFirstLineEnum<TEnum>()` extension method to retrieve the first line of a section as an enum value.
* Also includes unit tests covering successful parsing, case-insensitive parsing, and invalid enum values.